### PR TITLE
Add configurable random sampling for event displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ Change the path in `data/datafiles.json`
 python3 prepareDQMPlots.py
 python3 makeDQMPlots.py
 ```
+
+## Event display generation
+
+You can create event display PNGs and an HTML viewer with
+`makeEventDisplays.py`. The script supports sampling options so the output
+HTML can show a random subset of events.
+
+```bash
+python3 makeEventDisplays.py your_file.root \
+    --random-per-block 1 --block-size 100 --nth-interval 20
+```
+
+The example above selects one random event in every block of 100 events and
+also includes every 20th event.
 # CaloXDataAnalysis
 # CaloXDataAnalysis
 # CaloXDataAnalysis

--- a/utils/html_generator.py
+++ b/utils/html_generator.py
@@ -1,7 +1,8 @@
 import os
 
 
-def generate_html(png_files, png_dir, plots_per_row=4, output_html="view_plots.html"):
+def generate_html(png_files, png_dir, plots_per_row=4, output_html="view_plots.html",
+                  random_per_block=None, block_size=100, nth_interval=None):
     """
     Generate an HTML file to view PNG plots in a grid layout.
 
@@ -10,11 +11,33 @@ def generate_html(png_files, png_dir, plots_per_row=4, output_html="view_plots.h
     - png_dir (str or Path): path to the directory containing the PNG files
     - plots_per_row (int): number of plots to show per row
     - output_html (str): path to output HTML file
+    - random_per_block (int or None): if set, randomly select this many plots in
+      every ``block_size`` plots
+    - block_size (int): size of the block used for ``random_per_block``
+    - nth_interval (int or None): if set, also include every ``nth_interval``-th
+      plot in the HTML output
     """
 
     html_dir = os.path.dirname(os.path.abspath(output_html))
     png_dir_abs = os.path.abspath(png_dir)
     output_html_abs = os.path.abspath(output_html)
+
+    n_files = len(png_files)
+    indices = set()
+
+    if nth_interval and nth_interval > 0:
+        indices.update(range(0, n_files, nth_interval))
+
+    if random_per_block and block_size and random_per_block > 0:
+        import random
+        for start in range(0, n_files, block_size):
+            end = min(start + block_size, n_files)
+            count = min(random_per_block, end - start)
+            indices.update(random.sample(range(start, end), count))
+
+    if indices:
+        indices = sorted(indices)
+        png_files = [png_files[i] for i in indices]
 
     png_paths = [os.path.join(png_dir, f) for f in png_files]
     rel_paths = [os.path.relpath(png_path, start=html_dir)


### PR DESCRIPTION
## Summary
- extend HTML generator to optionally sample plots either randomly or at fixed intervals
- add corresponding options in `makeEventDisplays.py` with CLI support
- document how to use sampling options in README

## Testing
- `python3 -m py_compile makeEventDisplays.py utils/html_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_685d7a8bb29c832f934ea6280adf540f