### PR TITLE
Fix random event sampling for paired images

### DIFF
--- a/makeEventDisplays.py
+++ b/makeEventDisplays.py
@@ -233,6 +233,7 @@ def makeEventDisplays(infilename, random_per_block=None, block_size=100,
         random_per_block=random_per_block,
         block_size=block_size,
         nth_interval=nth_interval,
+        group_size=2,
     )
     generate_html(
         plots_pulse_shapes,


### PR DESCRIPTION
## Summary
- improve sampling logic in `generate_html` to handle grouped images per event
- ensure both Sci and Cer views are included for sampled events

## Testing
- `python -m py_compile makeEventDisplays.py utils/html_generator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d890609ac832f9061c823cd8d83c9